### PR TITLE
IE-0002: Automatic gitignores for Inform projects

### DIFF
--- a/proposals/0002-inform-project-gitignores.md
+++ b/proposals/0002-inform-project-gitignores.md
@@ -1,6 +1,7 @@
 # (IE-0002) Automatic gitignores for Inform projects
 
 * Proposal: [IE-0002](0002-inform-project-gitignores.md)
+* Reference link: [#2](https://github.com/ganelson/inform-evolution/pull/2)
 * Authors: Graham Nelson
 * Language feature name: None
 * Status: Draft


### PR DESCRIPTION
- Proposal: [IE-0002](https://github.com/ganelson/inform-evolution/blob/main/proposals/0002-inform-project-gitignores.md)
- Authors: Graham Nelson
- Language feature name: None
- Status: Draft
- Related proposals: None
- Implementation: None

## Summary

An automated convenience for Inform users placing projects under source control with git in its various guises.