### PR TITLE
IE-0004: Access to data files embedded in blorbs

### DIFF
--- a/proposals/0004-using-data-files-in-blorbs.md
+++ b/proposals/0004-using-data-files-in-blorbs.md
@@ -1,6 +1,7 @@
 # (IE-0004) Access to data files embedded in blorbs
 
 * Proposal: [IE-0004](0004-using-data-files-in-blorbs.md)
+* Reference link: [#4](https://github.com/ganelson/inform-evolution/pull/4)
 * Authors: Andrew Plotkin and Graham Nelson
 * Language feature name: None
 * Status: Draft


### PR DESCRIPTION
- Proposal: [IE-0004](https://github.com/ganelson/inform-evolution/blob/main/proposals/0004-using-data-files-in-blorbs.md)
- Authors: Andrew Plotkin and Graham Nelson
- Language feature name: None
- Status: Draft
- Related proposals: None
- Implementation: None

## Summary

The ability to read binary data files included in a blorbed release of a game.