### PR TITLE
IE-0005: Removing translates into Unicode

### DIFF
--- a/proposals/0005-removing-translates-into-unicode.md
+++ b/proposals/0005-removing-translates-into-unicode.md
@@ -1,6 +1,7 @@
 # (IE-0005) Removing translates into Unicode
 
 * Proposal: [IE-0005](0005-removing-translates-into-unicode.md)
+* Reference link: [#5](https://github.com/ganelson/inform-evolution/pull/5)
 * Authors: Graham Nelson
 * Language feature name: None
 * Status: Draft


### PR DESCRIPTION
- Proposal: [IE-0005](https://github.com/ganelson/inform-evolution/blob/main/proposals/0005-removing-translates-into-unicode.md)
- Authors: Graham Nelson
- Language feature name: None
- Status: Draft
- Related proposals: None
- Implementation: None

## Summary

Providing Unicode character names without slowly loading large cumbersome extensions, as has to be done at present.