### PR TITLE
IE-0006: New annotations for I6 syntax

### DIFF
--- a/proposals/0006-i6-syntax-annotations.md
+++ b/proposals/0006-i6-syntax-annotations.md
@@ -1,6 +1,7 @@
 # (IE-0006) New annotations for I6 syntax
 
 * Proposal: [IE-0006](0006-i6-syntax-annotations.md)
+* Reference link: [#6](https://github.com/ganelson/inform-evolution/pull/6)
 * Authors: Graham Nelson, David Kinder, and Andrew Plotkin
 * Language feature name: None
 * Status: Draft


### PR DESCRIPTION
- Proposal: [IE-0006](https://github.com/ganelson/inform-evolution/blob/main/proposals/0006-i6-syntax-annotations.md)
- Authors: Graham Nelson, David Kinder, and Andrew Plotkin
- Language feature name: None
- Status: Draft
- Related proposals: https://github.com/DavidKinder/Inform6/issues/189.
- Implementation: None

## Summary

A standard way to mark up Inform 6 syntax to provide annotations to help tools with linking or compilation, but which do not change its basic meaning.