### PR TITLE
IE-0007: Double-precision real numbers

### DIFF
--- a/proposals/0007-double-precision-reals.md
+++ b/proposals/0007-double-precision-reals.md
@@ -1,6 +1,7 @@
 # (IE-0007) Double-precision real numbers
 
 * Proposal: [IE-0007](0007-double-precision-reals.md)
+* Reference link: [#7](https://github.com/ganelson/inform-evolution/pull/7)
 * Authors: Andrew Plotkin and Graham Nelson
 * Language feature name: None
 * Status: Draft


### PR DESCRIPTION
- Proposal: [IE-0007](https://github.com/ganelson/inform-evolution/blob/main/proposals/0007-double-precision-reals.md)
- Authors: Andrew Plotkin and Graham Nelson
- Language feature name: None
- Status: Draft
- Related proposals: None
- Implementation: None

## Summary

Quietly double the precision of real-number arithmetic used in Inform projects, without the user needing to do anything to make this happen.