### PR TITLE
IE-0013: Annotations for kit linking

### DIFF
--- a/proposals/0013-annotations-for-kit-linking.md
+++ b/proposals/0013-annotations-for-kit-linking.md
@@ -1,7 +1,7 @@
 # (IE-0013) Annotations for kit linking
 
 * Proposal: [IE-0013](0013-annotations-for-kit-linking.md)
-* Discussion PR link: [#13](https://github.com/ganelson/inform-evolution/pull/13)
+* Discussion PR link: [#13](https://github.com/ganelson/inform-evolution/pull/13) 
 * Authors: Graham Nelson
 * Language feature name: --
 * Status: Draft


### PR DESCRIPTION
* Proposal: [IE-0013](https://github.com/ganelson/inform-evolution/blob/main/proposals/0013-annotations-for-kit-linking.md)
* Authors: Graham Nelson
* Language feature name: --
* Status: Draft
* Related proposals: #6
* Implementation: Partly implemented but unreleased

## Summary

A simple set of annotations, in the sense of #0006, so that directives in the source code for kits or in `Include (- ... -)` code can be marked up in ways which affect how they are linked.