### PR TITLE
IE-0014: Inter names for rulebooks

### DIFF
--- a/proposals/0014-inter-names-for-rulebooks.md
+++ b/proposals/0014-inter-names-for-rulebooks.md
@@ -1,7 +1,7 @@
 # (IE-0014) Inter names for rulebooks
 
 * Proposal: [IE-0014](0014-inter-names-for-rulebooks.md)
-* Discussion PR link: [#14](https://github.com/ganelson/inform-evolution/pull/14) 
+* Discussion PR link: [#14](https://github.com/ganelson/inform-evolution/pull/14)  
 * Authors: Graham Nelson
 * Language feature name: --
 * Status: Draft


### PR DESCRIPTION
* Proposal: [IE-0014](https://github.com/ganelson/inform-evolution/blob/main/proposals/0014-inter-names-for-rulebooks.md)
* Authors: Graham Nelson
* Language feature name: --
* Status: Draft
* Related proposals: [IE-0013](0013-annotations-for-kit-linking.md)
* Implementation: Implemented but unreleased

## Summary

A purely additive change to the `translates into Inter as...` sentence syntax,
allowing explicit Inter identifier names to be assigned to be rulebooks and
activities created in source text. In particular, this allows kits to access
rulebooks and activities created in extensions.