### PR TITLE
IE-0015: World model enforcement

### DIFF
--- a/proposals/0015-world-model-enforcement.md
+++ b/proposals/0015-world-model-enforcement.md
@@ -1,7 +1,7 @@
 # (IE-0015) World model enforcement
 
 * Proposal: [IE-0015](0015-world-model-enforcement.md)
-* Discussion PR link: [#15](https://github.com/ganelson/inform-evolution/pull/15)  
+* Discussion PR link: [#15](https://github.com/ganelson/inform-evolution/pull/15)
 * Authors: Graham Nelson
 * Language feature name: --
 * Status: Draft


### PR DESCRIPTION
- Proposal: [IE-0015](https://github.com/ganelson/inform-evolution/blob/main/proposals/0015-world-model-enforcement.md)
- Authors: Graham Nelson
- Language feature name: --
- Status: Draft
- Related proposals: --
- Implementation: Experiments in progress

## Summary

WorldModelKit and the Standard Rules, together with support hard-wired into the if module of the Inform compiler, collectively provide a "world model". At present it is not as consistent or as well-enforced as we would like, and this leads to unexpected and unhelpful behaviour. IE-0015 gathers up a set of changes to improve (though not fully fix) matters in one place, rather than leaving these in scattered responses to bug reports.