### PR TITLE
IE-0025: Kit-enumerated kinds

### DIFF
--- a/proposals/0025-kit-enumerated-kinds.md
+++ b/proposals/0025-kit-enumerated-kinds.md
@@ -4,7 +4,7 @@
 * Discussion PR link: [#25](https://github.com/ganelson/inform-evolution/pull/25)
 * Authors: Graham Nelson
 * Language feature name: --
-* Status: Draft
+* Status: Implemented but unreleased
 * Related proposals: --
 * Implementation: Implemented but unreleased
 


### PR DESCRIPTION
* Proposal: [IE-0025](https://github.com/ganelson/inform-evolution/blob/main/proposals/0025-kit-enumerated-kinds.md)
* Authors: Graham Nelson
* Language feature name: --
* Status: Implemented but unreleased
* Related proposals: --
* Implementation: Implemented but unreleased

## Summary

Extends the Neptune mini-language, by which kits can add new kinds of value to the
Inform language, to allow enumerations to be created whose run-time values are
not necessarily 1, 2, 3, ..., and no longer need to be contiguous.