### PR TITLE
IE-0035: Ambiguously plural property

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ scale, have since 30 July 2022 been proposed and tracked in this repository.
 The core repository for the language itself is
 [ganelson/inform](https://github.com/ganelson/inform).
 
-## In progress
+## In progress 
 
 Proposal                                                                                                 | Began             | Comments
 -------------------------------------------------------------------------------------------------------- | ----------------- | --------


### PR DESCRIPTION
* Proposal: [IE-0035](https://github.com/ganelson/inform-evolution/blob/main/proposals/0035-ambiguously-plural-property.md)
* Authors: Graham Nelson
* Status: Accepted
* Implementation: Implemented but unreleased

## Summary

To make the ambiguously plural property cause an object to set both of the command parser's pronouns IT and THEM, regardless of whether the object is singular-named or plural-named. By contrast, an object which is not ambiguously plural sets IT if it is singular-named and THEM if it is plural-named, but not both. The idea is to give this property to things with names such as "string of pearls", so that TAKE STRING. EXAMINE IT and TAKE PEARLS. EXAMINE THEM would both work.