### PR TITLE
IE-0036: Extension licencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ scale, have since 30 July 2022 been proposed and tracked in this repository.
 The core repository for the language itself is
 [ganelson/inform](https://github.com/ganelson/inform).
 
-## In progress 
+## In progress
 
 Proposal                                                                                                 | Began             | Comments
 -------------------------------------------------------------------------------------------------------- | ----------------- | --------


### PR DESCRIPTION
* Proposal: [IE-0036](https://github.com/ganelson/inform-evolution/blob/main/proposals/0036-extension-licencing.md)
* Authors: Graham Nelson
* Status: Draft
* Related proposals: --
* Implementation: None as yet

## Summary

Provides for extensions, and also projects and other Inform resources, to say explicitly under what legal terms they can be used.