### PR TITLE
IE-0038: Division of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ scale, have since 30 July 2022 been proposed and tracked in this repository.
 The core repository for the language itself is
 [ganelson/inform](https://github.com/ganelson/inform).
 
-## In progress 
+## In progress
 
 Proposal                                                                                                 | Began             | Comments
 -------------------------------------------------------------------------------------------------------- | ----------------- | --------


### PR DESCRIPTION
* Proposal: [IE-0038](https://github.com/ganelson/inform-evolution/blob/main/proposals/0038-division-of-time.md)
* Authors: Graham Nelson
* Status: Accepted
* Related proposals: #37
* Implementation: Implemented but unreleased

## Summary

Inform's existing kind `time` is split into two different concepts. `time`
continues to be used for values like `12:23 pm`, which are possible times
of day, whereas `time period` is introduced as a new built-in kind to
hold `12 minutes`, `minus 34 hours 10 minutes` and so on.