### PR TITLE
IE-0040: Version number kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ scale, have since 30 July 2022 been proposed and tracked in this repository.
 The core repository for the language itself is
 [ganelson/inform](https://github.com/ganelson/inform).
 
-## In progress 
+## In progress
 
 Proposal                                                                                                 | Began             | Comments
 -------------------------------------------------------------------------------------------------------- | ----------------- | --------


### PR DESCRIPTION
* Proposal: [IE-0040](https://github.com/ganelson/inform-evolution/blob/main/proposals/0040-version-number-kind.md)
* Authors: Graham Nelson
* Status: Draft
* Related proposals: --
* Implementation: None as yet

## Summary

Adds a `version number` kind, whose constant values can be written `v16`, `v2.4`
or `v2.3.12`.