### PR TITLE
IE-0041: Very first and very last rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ scale, have since 30 July 2022 been proposed and tracked in this repository.
 The core repository for the language itself is
 [ganelson/inform](https://github.com/ganelson/inform).
 
-## In progress
+## In progress 
 
 Proposal                                                                                                 | Began             | Comments
 -------------------------------------------------------------------------------------------------------- | ----------------- | --------


### PR DESCRIPTION
* Proposal: [IE-0041](https://github.com/ganelson/inform-evolution/blob/main/proposals/0041-very-first-rules.md)
* Authors: Graham Nelson
* Status: Accepted
* Related proposals: None
* Status: Implemented but unreleased

## Summary

To provide for rulebooks to have a designed `very first` rule, guaranteed
always to be present, which can initialise rulebook variables before any other
rules can access them. For symmetry, `very last` rules are also provided.